### PR TITLE
Add events usage example, with an example of switching the view

### DIFF
--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -2,14 +2,30 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   setupController: function(controller) {
-    controller.set('viewName', 'reflectui-examples');
-    controller.set('project', 'report');
-    controller.set('token', 'adb30a82-ab3a-4036-85d7-ad5584b97acf');
+    controller.set('project', 'reflect-productivity');
+    controller.set('viewName', 'simple-dashboard-view');
+    controller.set('token', 'c77b12dd-a370-48be-9b94-ee388b14510c');
 
-    controller.set('events', {
-      'datagrid-1': {tableCellClick: [(data) => console.log(data)]}
-    });
+    // timeseries is the slug of the component we're targeting.
+    // legendItemClick is the event we're going to handlers for.
+    let events = {
+      timeseries: {
+        legendItemClick: [
+          (data) => {
+            // This will change our controller viewName value, thus
+            // changing the Reflect view that gets rendered.
+            controller.set('viewName', 'even-simpler-dashboard');
 
-    controller.set('filters', []);
+            // This will set the filters to filter for the series we clicked on.
+            controller.set('filters', [
+              {field: data.field, op: '=', value: data.value, removable: true}
+            ]);
+          }
+        ]
+      }
+    };
+
+    // We need to pass these event handlers to the Reflect component.
+    controller.set('events', events);
   }
 });


### PR DESCRIPTION
Users can test this out by running `ember s`, then clicking on a legend item in the top timeseries component. It'll add a filter and switch the view.