### PR TITLE
Destroy the reflect view before it gets removed from the DOM.

### DIFF
--- a/addon/components/reflect-view.js
+++ b/addon/components/reflect-view.js
@@ -69,6 +69,8 @@ export default Ember.Component.extend({
   },
 
   willDestroyElement: function() {
-    this.ui.destroy(this.element);
+    if (this.ui && this.ui.destroy) {
+      this.ui.destroy(this.element);
+    }
   }
 });

--- a/addon/components/reflect-view.js
+++ b/addon/components/reflect-view.js
@@ -66,5 +66,9 @@ export default Ember.Component.extend({
     }
 
     this.ui.view(this.element, project, view);
+  },
+
+  willDestroyElement: function() {
+    this.ui.destroy(this.element);
   }
 });


### PR DESCRIPTION
This will clean up the various event handlers used within reflect