### PR TITLE
RFL-1455: Add support for view identifiers

### DIFF
--- a/addon/components/reflect-view.js
+++ b/addon/components/reflect-view.js
@@ -70,7 +70,7 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    assert('<reflect-view:project>: Missing project slug', this._validateString('project'));
+    assert('<reflect-view:view>: Missing view identifier', this._validateString('view'));
 
     const { dates } = this.getProperties('dates');
 
@@ -81,6 +81,9 @@ export default Component.extend({
   },
 
   didRender() {
+    const project = get(this, 'project');
+    const view = get(this, 'view');
+
     if (get(this, 'parameters')) {
       this.ui.withParameters(get(this, 'parameters'));
     }
@@ -117,7 +120,11 @@ export default Component.extend({
       this.ui.withTimezone(get(this, 'timezone'));
     }
 
-    this.ui.view(this.element, get(this, 'project'), get(this, 'view'));
+    if (!project) {
+      this.ui.view(this.element, view);
+    } else {
+      this.ui.view(this.element, project, view);
+    }
 
     this._applyInteractionCallbacks();
   },

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -13,9 +13,7 @@ export default Controller.extend({
     this._super(...arguments);
 
     this.setProperties({
-      project: 'reflect-productivity',
-      viewName: 'simple-dashboard-view',
-      token: 'c77b12dd-a370-48be-9b94-ee388b14510c',
+      view: 'ZFSzsfnRSpaMHL9Wae3lHw',
       // events: {
       //   timeseries: {
       //     dataPointClick: [

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,13 +1,11 @@
 {{reflect-view
   filters=filters
-  token=token
-  project=project
   events=events
   dates=dates
   colors=colors
   formatters=formatters
   overrides=overrides
   timezone=timezone
-  view=viewName
+  view=view
   interactions=interactions
 }}

--- a/tests/integration/components/reflect-view-test.js
+++ b/tests/integration/components/reflect-view-test.js
@@ -12,7 +12,7 @@ test('it renders', function(assert) {
   this.set('token', ['']);
 
   this.render(hbs`
-    {{reflect-view project="LOkOQjwlTamH4fyQlHBu8A"}}
+    {{reflect-view view="LOkOQjwlTamH4fyQlHBu8A"}}
   `);
 
   assert.equal(this.$().text().trim(), '');


### PR DESCRIPTION
This adds support for explicitly using view identifiers in the same style as Reflect.js. Both the old integration style (`token="1234-abcd-..." project="foo" view="bar"`) and the new integration style (`view="AbCd123"`) are supported.